### PR TITLE
Add status REST command to broker

### DIFF
--- a/broker/server.py
+++ b/broker/server.py
@@ -183,13 +183,14 @@ async def run_feeder(background_tasks: BackgroundTasks):
 async def status():
     try:
         name_2_timedata = {}
-        if h.helicsBrokerIsConnected(app.state.broker) is True:
+        connected = h.helicsBrokerIsConnected(app.state.broker)
+        if connected:
             for time_data in get_time_data(app.state.broker):
                 if (time_data.name not in name_2_timedata) or (
                     name_2_timedata[time_data.name] != time_data
                 ):
                     name_2_timedata[time_data.name] = time_data
-        return {"timedata": name_2_timedata, "error": False}
+        return {"connected": connected, "timedata": name_2_timedata, "error": False}
         # return {"status": app.state.broker.granted_time, "error": False}
     except AttributeError as e:
         return {"reply": str(e), "error": True}

--- a/broker/server.py
+++ b/broker/server.py
@@ -191,7 +191,6 @@ async def status():
                 ):
                     name_2_timedata[time_data.name] = time_data
         return {"connected": connected, "timedata": name_2_timedata, "error": False}
-        # return {"status": app.state.broker.granted_time, "error": False}
     except AttributeError as e:
         return {"reply": str(e), "error": True}
 


### PR DESCRIPTION
- Queries most recently started broker
- Returns with an error before starting
- Returns with connected true/false + time data dictionary (in form of get_time_data from oedisi.tools.broker_utils)

I considered to using websockets to provide this intermittently, but there's not a way I could see in HELICS to get time data without polling.

We don't have any integration tests for docker compose yet, so that should be a separate pull request.

Closes #57