### PR TITLE
Use all bus names + auto-add [1, 2, 3] to get core names

### DIFF
--- a/LocalFeeder/FeederSimulator.py
+++ b/LocalFeeder/FeederSimulator.py
@@ -153,16 +153,16 @@ class FeederSimulator(object):
 
     def forcast_pv(self, steps: int) -> list:
         """
-        Forecasts day ahead PV generation for the OpenDSS feeder. The OpenDSS file is run and the 
+        Forecasts day ahead PV generation for the OpenDSS feeder. The OpenDSS file is run and the
         average irradiance is computed over all PV systems for each time step. This average irradiance
         is used to compute the individual PV system power output
         """
-        cmd = f'Set stepsize={self._simulation_time_step} Number=1'
+        cmd = f"Set stepsize={self._simulation_time_step} Number=1"
         dss.Text.Command(cmd)
         forecast = []
         for k in range(steps):
             dss.Solution.Solve()
-            
+
             # names of PV systems and forecasted power output
             pv_names = []
             powers = []
@@ -171,7 +171,7 @@ class FeederSimulator(object):
             flag = dss.PVsystems.First()
             avg_irradiance = dss.PVsystems.IrradianceNow()
             while flag:
-                avg_irradiance = (avg_irradiance + dss.PVsystems.IrradianceNow())/2
+                avg_irradiance = (avg_irradiance + dss.PVsystems.IrradianceNow()) / 2
                 flag = dss.PVsystems.Next()
 
             # now compute the power output from the evaluated average irradiance
@@ -180,7 +180,7 @@ class FeederSimulator(object):
                 pv_names.append(f"PVSystem.{dss.PVsystems.Name()}")
                 powers.append(dss.PVsystems.Pmpp() * avg_irradiance)
                 flag = dss.PVsystems.Next()
-            
+
             forecast.append(xr.DataArray(powers, coords={"ids": pv_names}))
         return forecast
 
@@ -467,17 +467,16 @@ class FeederSimulator(object):
         for ld in get_loads(dss, self._circuit):
             self._circuit.SetActiveElement("Load." + ld["name"])
             current_pq_name = dss.CktElement.Name()
-            for ii in range(len(ld["phases"])):
-                node_name = ld["bus1"].upper() + "." + ld["phases"][ii]
+            for i, node_name in enumerate(ld["node_names"]):
                 assert (
                     node_name in all_node_names
                 ), f"{node_name} for {current_pq_name} not found"
                 if static:
                     power = complex(ld["kW"], ld["kVar"])
-                    PQs.append(power / len(ld["phases"]))
+                    PQs.append(power / ld["numPhases"])
                 else:
                     power = dss.CktElement.Powers()
-                    PQs.append(complex(power[2 * ii], power[2 * ii + 1]))
+                    PQs.append(complex(power[2 * i], power[2 * i + 1]))
                 pq_names.append(current_pq_name)
                 node_names.append(node_name)
         pq_xr = xr.DataArray(
@@ -499,13 +498,9 @@ class FeederSimulator(object):
         node_names: List[str] = []
         pq_names: List[str] = []
         for PV in get_pvsystems(dss):
-            bus = PV["bus"].split(".")
-            if len(bus) == 1:
-                bus = bus + ["1", "2", "3"]
             self._circuit.SetActiveElement("PVSystem." + PV["name"])
             current_pq_name = dss.CktElement.Name()
-            for ii in range(len(bus) - 1):
-                node_name = bus[0].upper() + "." + bus[ii + 1]
+            for i, node_name in enumerate(PV["node_names"]):
                 assert (
                     node_name in all_node_names
                 ), f"{node_name} for {current_pq_name} not found"
@@ -513,10 +508,10 @@ class FeederSimulator(object):
                     power = complex(
                         -1 * PV["kW"], -1 * PV["kVar"]
                     )  # -1 because injecting
-                    PQs.append(power / (len(bus) - 1))
+                    PQs.append(power / PV["numPhases"])
                 else:
                     power = dss.CktElement.Powers()
-                    PQs.append(complex(power[2 * ii], power[2 * ii + 1]))
+                    PQs.append(complex(power[2 * i], power[2 * i + 1]))
                 pq_names.append(current_pq_name)
                 node_names.append(node_name)
         pq_xr = xr.DataArray(
@@ -538,13 +533,10 @@ class FeederSimulator(object):
         node_names: List[str] = []
         pq_names: List[str] = []
         for gen in get_generators(dss):
-            bus = gen["bus"].split(".")
-            if len(bus) == 1:
-                bus = bus + ["1", "2", "3"]
             self._circuit.SetActiveElement("Generator." + gen["name"])
             current_pq_name = dss.CktElement.Name()
-            for ii in range(len(bus) - 1):
-                node_name = bus[0].upper() + "." + bus[ii + 1]
+
+            for i, node_name in enumerate(gen["node_names"]):
                 assert (
                     node_name in all_node_names
                 ), f"{node_name} for {current_pq_name} not found"
@@ -552,10 +544,10 @@ class FeederSimulator(object):
                     power = complex(
                         -1 * gen["kW"], -1 * gen["kVar"]
                     )  # -1 because injecting
-                    PQs.append(power / (len(bus) - 1))
+                    PQs.append(power / gen["numPhases"])
                 else:
                     power = dss.CktElement.Powers()
-                    PQs.append(complex(power[2 * ii], power[2 * ii + 1]))
+                    PQs.append(complex(power[2 * i], power[2 * i + 1]))
                 pq_names.append(current_pq_name)
                 node_names.append(node_name)
         pq_xr = xr.DataArray(
@@ -578,8 +570,7 @@ class FeederSimulator(object):
         pq_names: List[str] = []
         for cap in get_capacitors(dss):
             current_pq_name = cap["name"]
-            for ii in range(cap["numPhases"]):
-                node_name = cap["busname"].upper() + "." + cap["busphase"][ii]
+            for i, node_name in enumerate(cap["node_names"]):
                 assert (
                     node_name in all_node_names
                 ), f"{node_name} for {current_pq_name} not found"
@@ -589,7 +580,7 @@ class FeederSimulator(object):
                     )  # -1 because it's injected into the grid
                     PQs.append(power / cap["numPhases"])
                 else:
-                    PQs.append(complex(0, cap["power"][2 * ii + 1]))
+                    PQs.append(complex(0, cap["power"][2 * i + 1]))
                 pq_names.append(current_pq_name)
                 node_names.append(node_name)
         pq_xr = xr.DataArray(

--- a/LocalFeeder/dss_functions.py
+++ b/LocalFeeder/dss_functions.py
@@ -1,4 +1,5 @@
 """OpenDSS functions. Mutates global state, originally from GO-Solar project."""
+
 import math
 
 
@@ -18,14 +19,15 @@ def get_loads(dss, circuit):
         }
         _ = circuit.SetActiveElement("Load.%s" % datum["name"])
         cktElement = dss.CktElement
-        bus = cktElement.BusNames()[0].split(".")
+        buses = cktElement.BusNames()
+        bus = buses[0].split(".")
         datum["kVar"] = (
             float(datum["kW"])
             / float(datum["PF"])
             * math.sqrt(1 - float(datum["PF"]) * float(datum["PF"]))
         )
         datum["bus1"] = bus[0]
-        datum["numPhases"] = len(bus[1:])
+        datum["numPhases"] = dss.CktElement.NumPhases()
         datum["phases"] = bus[1:]
         if not datum["numPhases"]:
             datum["numPhases"] = 3
@@ -33,6 +35,7 @@ def get_loads(dss, circuit):
         datum["voltageMag"] = cktElement.VoltagesMagAng()[0]
         datum["voltageAng"] = cktElement.VoltagesMagAng()[1]
         datum["power"] = dss.CktElement.Powers()[:2]
+        datum["node_names"] = get_all_nodes(buses)
 
         data.append(datum)
         load_flag = dss.Loads.Next()
@@ -55,7 +58,8 @@ def get_pvsystems(dss):
         PVkvar = dss.PVsystems.kvar()
 
         NumPhase = dss.CktElement.NumPhases()
-        bus = dss.CktElement.BusNames()[0]
+        buses = dss.CktElement.BusNames()
+        bus = buses[0].split(".")
         # PVkV = dss.run_command('? ' + PVname + '.kV')
         # Not included in PVsystems commands for some reason
 
@@ -70,10 +74,25 @@ def get_pvsystems(dss):
         datum["numPhase"] = NumPhase
         datum["numPhases"] = NumPhase
         datum["power"] = dss.CktElement.Powers()[: 2 * NumPhase]
+        datum["node_names"] = get_all_nodes(buses)
 
         data.append(datum)
         PV_flag = dss.PVsystems.Next()
     return data
+
+
+def get_all_nodes(buses: list[str]):
+    """Get all nodes from list of buses."""
+    all_nodes = []
+    for bus in buses:
+        sub_bus = bus.split(".")
+        core_name = sub_bus[0].upper()
+        phases = sub_bus[1:]
+        if len(phases) == 0:
+            all_nodes += [core_name + ".1", core_name + ".2", core_name + ".3"]
+        else:
+            all_nodes += [core_name + "." + phase for phase in phases]
+    return all_nodes
 
 
 def get_generators(dss):
@@ -84,13 +103,11 @@ def get_generators(dss):
     while gen_flag:
         GENname = dss.Generators.Name()
         NumPhase = dss.CktElement.NumPhases()
-        bus = dss.CktElement.BusNames()[0]
+        buses = dss.CktElement.BusNames()
+        bus = buses[0].split(".")
         GENkW = dss.Generators.kW()
         GENpf = dss.Generators.PF()
         GENkV = dss.Generators.kV()
-        bus = bus.split(".")
-        if len(bus) == 1:
-            bus = bus + ["1", "2", "3"]
         datum = {
             "name": GENname,
             "bus": bus,
@@ -102,6 +119,7 @@ def get_generators(dss):
             "kV": GENkV,
             "numPhase": NumPhase,
             "numPhases": NumPhase,
+            "node_names": get_all_nodes(buses),
         }
         data.append(datum)
         gen_flag = dss.Generators.Next()
@@ -117,7 +135,8 @@ def get_capacitors(dss):
         datum = {}
         capname = dss.CktElement.Name()
         NumPhase = dss.CktElement.NumPhases()
-        bus = dss.CktElement.BusNames()[0]
+        buses = dss.CktElement.BusNames()
+        bus = buses[0]
         kvar = dss.Capacitors.kvar()
         datum["name"] = capname
         temp = bus.split(".")
@@ -128,6 +147,7 @@ def get_capacitors(dss):
         datum["kVar"] = kvar
         datum["numPhases"] = NumPhase
         datum["power"] = dss.CktElement.Powers()[: 2 * NumPhase]
+        datum["node_names"] = get_all_nodes(buses[:1])  # second is 0
         data.append(datum)
         cap_flag = dss.Capacitors.Next()
     return data

--- a/LocalFeeder/dss_functions.py
+++ b/LocalFeeder/dss_functions.py
@@ -90,8 +90,10 @@ def get_all_nodes(buses: list[str]):
         phases = sub_bus[1:]
         if len(phases) == 0:
             all_nodes += [core_name + ".1", core_name + ".2", core_name + ".3"]
-        else:
-            all_nodes += [core_name + "." + phase for phase in phases]
+            continue
+        phases = filter(lambda x: x != "0", phases)
+        all_nodes += [core_name + "." + phase for phase in phases]
+
     return all_nodes
 
 
@@ -147,7 +149,7 @@ def get_capacitors(dss):
         datum["kVar"] = kvar
         datum["numPhases"] = NumPhase
         datum["power"] = dss.CktElement.Powers()[: 2 * NumPhase]
-        datum["node_names"] = get_all_nodes(buses[:1])  # second is 0
+        datum["node_names"] = get_all_nodes(buses)  # second is 0
         data.append(datum)
         cap_flag = dss.Capacitors.Next()
     return data

--- a/LocalFeeder/tests/test_data/master.dss
+++ b/LocalFeeder/tests/test_data/master.dss
@@ -6,6 +6,9 @@ new generator.HRSST_PV_PMU  Phases=3   Bus1=HRSST_PV   kV = 0.48 conn=wye Model=
 
 New PVSystem.3P_ExistingSite4 phases=3 bus1=B51854_sec2     kV=0.416 kVA=523 irradiance=1 Pmpp=475 pf=1 %cutin=0.1 %cutout=0.1
 
+new generator.HRSST_PV_PMU_2 Phases=1   Bus1=HRSST_PV.0.1 kV = 0.48 conn=wye Model=1  kW=3049.66   kVAr=-109.69
+New PVSystem.3P_ExistingSite4_2 phases=1 bus1=B51854_sec2.0.1     kV=0.416 kVA=523 irradiance=1 Pmpp=475 pf=1 %cutin=0.1 %cutout=0.1
+
 Set Voltagebases=[0.12, 0.208, 0.24, 0.48, 7.2, 12.47]
 
 Calcvoltagebases

--- a/LocalFeeder/tests/test_data/master.dss
+++ b/LocalFeeder/tests/test_data/master.dss
@@ -4,6 +4,7 @@ New Circuit.test_feeder bus1=head_bus pu=1.03 basekV=12.47 R1=1e-05 X1=1e-05 R0=
 
 new generator.HRSST_PV_PMU  Phases=3   Bus1=HRSST_PV   kV = 0.48 conn=wye Model=1  kW=3049.66   kVAr=-109.69
 
+New PVSystem.3P_ExistingSite4 phases=3 bus1=B51854_sec2     kV=0.416 kVA=523 irradiance=1 Pmpp=475 pf=1 %cutin=0.1 %cutout=0.1
 
 Set Voltagebases=[0.12, 0.208, 0.24, 0.48, 7.2, 12.47]
 

--- a/LocalFeeder/tests/test_data/master.dss
+++ b/LocalFeeder/tests/test_data/master.dss
@@ -1,0 +1,14 @@
+Clear
+
+New Circuit.test_feeder bus1=head_bus pu=1.03 basekV=12.47 R1=1e-05 X1=1e-05 R0=1e-05 X0=1e-05
+
+new generator.HRSST_PV_PMU  Phases=3   Bus1=HRSST_PV   kV = 0.48 conn=wye Model=1  kW=3049.66   kVAr=-109.69
+
+
+Set Voltagebases=[0.12, 0.208, 0.24, 0.48, 7.2, 12.47]
+
+Calcvoltagebases
+
+set maxcontroliter=50
+
+Solve mode=yearly stepsize=15m number=1

--- a/LocalFeeder/tests/test_feeder.py
+++ b/LocalFeeder/tests/test_feeder.py
@@ -60,6 +60,24 @@ def federate_config():
     )
 
 
+@pytest.fixture()
+def edge_cases_config():
+    return FeederSimulator.FeederConfig(
+        **{
+            "use_smartds": False,
+            "profile_location": "",
+            "opendss_location": "",
+            "sensor_location": "",
+            "existing_feeder_file": "tests/test_data/master.dss",
+            "start_date": "2017-01-01 00:00:00",
+            "number_of_timesteps": 1,
+            "run_freq_sec": 900,
+            "topology_output": "topology.json",
+            "name": "feeder",
+        }
+    )
+
+
 def plot_y_matrix(Y):
     Y_max = np.max(np.abs(Y))
 
@@ -658,3 +676,11 @@ def test_incidence_matrix(federate_config):
         assert len(incidences.equipment_type) == len(incidences.from_equipment)
     if incidences.ids is not None:
         assert len(incidences.ids) == len(incidences.from_equipment)
+
+
+def test_edge_case(edge_cases_config):
+    sim = FeederSimulator.FeederSimulator(edge_cases_config)
+    sim.snapshot_run()
+    sim.get_PQs_gen(static=True)
+    sim.solve(0, 0)
+    sim.get_PQs_gen()

--- a/LocalFeeder/tests/test_feeder.py
+++ b/LocalFeeder/tests/test_feeder.py
@@ -683,4 +683,5 @@ def test_edge_case(edge_cases_config):
     sim.snapshot_run()
     sim.get_PQs_gen(static=True)
     sim.solve(0, 0)
-    sim.get_PQs_gen()
+    pq = sim.get_PQs_gen()
+    assert len(pq) == 4


### PR DESCRIPTION
Fixes Issue #84 

- Note that capacitors still have a special case, since one of the buses will be all ground usually. Hopefully this case doesn't come back.
- Added a regression test and both cases in the issue to a test_data/master.dss.