### PR TITLE
Use artifact upload v4

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -37,7 +37,7 @@ jobs:
 
         python post_analysis.py outputs_build
     - name: Archive logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: docker_logs

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -31,7 +31,7 @@ jobs:
         oedisi run
         python post_analysis.py
     - name: Archive logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test_logs

--- a/.github/workflows/test-dopf.yml
+++ b/.github/workflows/test-dopf.yml
@@ -38,7 +38,7 @@ jobs:
         oedisi run
         python opf_analysis.py
     - name: Archive logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test_logs


### PR DESCRIPTION
- upload v2 has been deprecated, which leads to failures for 3 of our github actions