### PR TITLE
Modify requirements.txt and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM python:3.10.6-slim-bullseye
-#USER root
-RUN apt-get update && apt-get install -y git ssh
-
-RUN mkdir -p /root/.ssh
+FROM python:3.11.10
 
 WORKDIR /simulation
 

--- a/LocalFeeder/requirements.txt
+++ b/LocalFeeder/requirements.txt
@@ -1,5 +1,4 @@
-helics==3.4.0
-helics-apps==3.4.0
+helics>=3.4.0
 pydantic
 pyarrow
 scipy

--- a/broker/requirements.txt
+++ b/broker/requirements.txt
@@ -1,5 +1,4 @@
-helics==3.4.0
-helics-apps==3.4.0
+helics>=3.4.0
 pyyaml
 fastapi
 uvicorn

--- a/lindistflow_federate/requirements.txt
+++ b/lindistflow_federate/requirements.txt
@@ -1,4 +1,4 @@
-helics==3.4.0
+helics>=3.4.0
 pydantic>=1.7,<2
 cvxpy
 numpy

--- a/measuring_federate/requirements.txt
+++ b/measuring_federate/requirements.txt
@@ -1,5 +1,4 @@
-helics==3.4.0
-helics-apps==3.4.0
+helics>=3.4.0
 pydantic
 pyarrow
 numpy
@@ -9,4 +8,3 @@ uvicorn
 requests
 grequests
 oedisi>=2.0.2,<3
-

--- a/recorder/requirements.txt
+++ b/recorder/requirements.txt
@@ -1,5 +1,4 @@
-helics==3.4.0
-helics-apps==3.4.0
+helics>=3.4.0
 pydantic
 pyarrow
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 numpy
 pandas
 oedisi>=2.0.2,<3
+helics>=3.6.1
 -r recorder/requirements.txt
 -r LocalFeeder/requirements.txt
 -r measuring_federate/requirements.txt

--- a/wls_federate/requirements.txt
+++ b/wls_federate/requirements.txt
@@ -1,5 +1,4 @@
-helics==3.4.0
-helics-apps==3.4.0
+helics>=3.4.0
 pydantic
 scipy
 numpy


### PR DESCRIPTION
Solves latest incarnation of #66 by using newer HELICS versions

- `helics-apps` has an ARM64 Mac build but not an ARM64 Linux build. Until that is fixed, we need to use the sdist and so we do not have a `slim-build` anymore.
- Requirements for helics-apps directly have been removed
- `helics` has been bumped to at least 3.6.1

