### PR TITLE
fix uv sync issue and add local dev guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,21 +161,39 @@ pre-commit run --all-files
 
 # Install and Running Locally
 
-## Installation
+## 1. Initialize Submodules
+Before installing or running any components, ensure all Git submodules are initialized and updated:
+```bash
+git submodule update --init --recursive
+```
 
-1. Install component dependencies. You can either:
+## 2. Installation
+Install the component dependencies in editable mode (recommended for development):
+```bash
+pip install -e Components/broker \
+            -e Components/lindistflow_federate \
+            -e Components/LocalFeeder \
+            -e Components/measuring_federate \
+            -e Components/recorder \
+            -e Components/wls_federate
+```
 
-   **Option A: Install all components in editable mode** (recommended for developers)
-   ```bash
-   pip install -e Components/broker \
-               -e Components/LocalFeeder \
-               -e Components/measuring_federate \
-               -e Components/recorder \
-               -e Components/wls_federate
-   ```
+To install development tools as well:
+```bash
+pip install pytest mypy ruff pre-commit
+```
 
-3. **Verify Installation**
- development tools (optional):
-   ```bash
-   pip install pytest mypy ruff pre-commit
-   ```
+## 3. Running Scenarios
+You can test and run co-simulation scenarios locally using `oedisi` build and run commands.
+
+First, build the co-simulation configuration from a scenario JSON file:
+```bash
+oedisi build --system scenarios/system.json
+```
+
+Then, run the co-simulation:
+```bash
+oedisi run
+```
+
+The output data will be stored in the `outputs/` directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,9 @@ exclude_lines = [
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
 ]
+
+[tool.uv]
+package = false
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
## Summary

  1. Resolved  `uv sync`  build issue by making root project a non-package metadata wrapper, stopping setuptools from trying to auto-discover packages in the root directory (which was getting confused by Components, outputs, and scenarios.
  2. Updated the "Install and Running Locally" section of README.md to outline: Initializing and updating Git submodules ( git submodule update --init --recursive ). Installing the core components in editable mode. Running/testing co-simulation scenarios locally using oedisi build --system scenarios/<scenario>.json  and oedisi run.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] New component

## Component Impact
N/A

## Required Checks

- [ ] Linting passes
- [ ] Formatting checks pass
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] I updated documentation and badges as needed
- [ ] I confirmed CI workflows and file paths are correct
- [x] I verified there are no unrelated changes in this PR
