### PR TITLE
Add EV load injection and iterative time flag

### DIFF
--- a/Components/LocalFeeder/src/localfeeder/FeederSimulator.py
+++ b/Components/LocalFeeder/src/localfeeder/FeederSimulator.py
@@ -72,6 +72,7 @@ class FeederConfig(BaseModel):
     start_time_index: int = 0
     topology_output: str = "topology.json"
     use_sparse_admittance: bool = False
+    iterative_time: bool = False
     tap_setting: int | None = None
     open_lines: list[str] | None = None
 
@@ -627,6 +628,60 @@ class FeederSimulator:
 
         return xr.DataArray(res_feeder_voltages, {"ids": list(name_voltage_dict.keys())})
 
+    def _build_load_bus_map(self):
+        self._load_bus_map = {}
+        load_flag = dss.Loads.First()
+        while load_flag:
+            load_name = dss.Loads.Name()
+            dss.Circuit.SetActiveElement(f"Load.{load_name}")
+            bus_names = dss.CktElement.BusNames()
+            if bus_names:
+                for bus in bus_names:
+                    bus_lower = bus.lower()
+                    self._load_bus_map[bus_lower] = load_name
+                    base_bus = bus_lower.split(".")[0]
+                    if base_bus not in self._load_bus_map:
+                        self._load_bus_map[base_bus] = load_name
+            self._load_bus_map[load_name.lower()] = load_name
+            load_flag = dss.Loads.Next()
+        logger.info(f"Built load-bus map: {len(self._load_bus_map)} entries")
+
+    def _find_load_for_bus(self, bus_id):
+        if not hasattr(self, "_load_bus_map"):
+            self._build_load_bus_map()
+        bus_lower = bus_id.lower()
+        if bus_lower in self._load_bus_map:
+            return self._load_bus_map[bus_lower]
+        base_bus = bus_lower.split(".")[0]
+        if base_bus in self._load_bus_map:
+            return self._load_bus_map[base_bus]
+        for key, load_name in self._load_bus_map.items():
+            if base_bus in key or key in base_bus:
+                return load_name
+        return None
+
+    def _apply_ev_injection(self, bus_id, obj_property, val):
+        ev_name = "evinj_" + bus_id.replace(".", "_").lower()
+        if not hasattr(self, "_ev_inject_loads"):
+            self._ev_inject_loads = set()
+        if ev_name not in self._ev_inject_loads:
+            template = self._find_load_for_bus(bus_id)
+            if template is None:
+                return
+            dss.Loads.Name(template)
+            kv = dss.Loads.kV()
+            vminpu = dss.Loads.Vminpu()
+            conn = "delta" if dss.Loads.IsDelta() else "wye"
+            dss.Circuit.SetActiveElement("Load." + template)
+            bus1 = dss.CktElement.BusNames()[0]
+            nph = dss.CktElement.NumPhases()
+            dss.Text.Command(
+                f"New Load.{ev_name} bus1={bus1} phases={nph} conn={conn} "
+                f"kV={kv} kW=0 kvar=0 model=1 Vminpu={vminpu} Vmaxpu=1.2"
+            )
+            self._ev_inject_loads.add(ev_name)
+        dss.Text.Command(f"Load.{ev_name}.{obj_property}={val}")
+
     def change_obj(self, change_commands: list[Command]):
         """set/get an object property.
 
@@ -641,9 +696,11 @@ class FeederSimulator:
         """
         assert self._state != OpenDSSState.UNLOADED, f"{self._state}"
         for entry in change_commands:
-            dss.Circuit.SetActiveElement(entry.obj_name)  # make the required element as active element
-            # dss.CktElement.Properties(entry.obj_property).Val = entry.val
-            # dss.Properties.Value(entry.obj_property, str(entry.val))
+            if entry.obj_name.lower().startswith("evload."):
+                bus_id = entry.obj_name.split(".", 1)[1]
+                self._apply_ev_injection(bus_id, entry.obj_property, entry.val)
+                continue
+            dss.Circuit.SetActiveElement(entry.obj_name)
             properties = dss.CktElement.AllPropertyNames()
             element_name = dss.CktElement.Name()
             assert entry.obj_property.lower() in map(

--- a/Components/LocalFeeder/src/localfeeder/sender_cosim.py
+++ b/Components/LocalFeeder/src/localfeeder/sender_cosim.py
@@ -320,9 +320,15 @@ def go_cosim(
     initial_timestamp = datetime.strptime(config.start_date, "%Y-%m-%d %H:%M:%S")
 
     while request_time < int(config.number_of_timesteps):
-        granted_time = h.helicsFederateRequestTime(vfed, request_time)
+        if config.iterative_time:
+            granted_time, iteration_state = h.helicsFederateRequestTimeIterative(
+                vfed, request_time, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+            )
+        else:
+            granted_time = h.helicsFederateRequestTime(vfed, request_time)
+            iteration_state = None
         assert granted_time <= request_time + deltat, f"granted_time: {granted_time} past {request_time}"
-        if granted_time >= request_time - deltat:
+        if not config.iterative_time and granted_time >= request_time - deltat:
             request_time += 1
 
         current_index = int(granted_time)  # floors
@@ -423,6 +429,9 @@ def go_cosim(
             )
 
         logger.info("end time: " + str(datetime.now()))
+
+        if config.iterative_time and iteration_state == h.HELICS_ITERATION_RESULT_NEXT_STEP:
+            request_time += 1
 
     h.helicsFederateDisconnect(vfed)
     h.helicsFederateFree(vfed)


### PR DESCRIPTION
EV load injection + iterative-time flag
Interim fix so the EV charging use case can place a controllable load at a bus.
- change_obj routes evload commands to a separate Load.evinj_<bus> (additive, shapeless). Every other command unaffected.
- add an iterative_time config flag,  only EV case set it on to enable the iterative control modes, non-EV use cases unaffected.