### PR TITLE
Add recorder time delta field

### DIFF
--- a/Components/recorder/schema.json
+++ b/Components/recorder/schema.json
@@ -11,6 +11,12 @@
     "feather_filename": {
       "title": "Feather Path",
       "type": "string"
+    },
+    "time_delta": {
+      "title": "Time Delta",
+      "description": "HELICS time resolution. Default 0.01.",
+      "type": "number",
+      "default": 0.01
     }
   },
   "required": ["csv_filename", "feather_filename"],

--- a/Components/recorder/src/recorder/record_subscription.py
+++ b/Components/recorder/src/recorder/record_subscription.py
@@ -19,6 +19,9 @@ logger.setLevel(logging.INFO)
 class Recorder:
     """HELICS recorder federate."""
 
+    # HELICS time resolution; 0.01 is fine for quasi-static simulations.
+    DEFAULT_TIME_DELTA = 0.01
+
     def __init__(
         self,
         name,
@@ -26,11 +29,11 @@ class Recorder:
         csv_filename,
         input_mapping,
         broker_config: BrokerConfig,
+        time_delta: float = DEFAULT_TIME_DELTA,
     ):
         """Initialize the recorder federate."""
         self.rng = np.random.default_rng(12345)
-        deltat = 0.01
-        # deltat = 60.
+        deltat = time_delta
 
         # Create Federate Info object that describes the federate properties #
         fedinfo = h.helicsCreateFederateInfo()
@@ -75,11 +78,12 @@ class Recorder:
                 logger.info("start time: " + str(datetime.now()))
                 logger.debug(granted_time)
                 # Check that the data is a MeasurementArray type
-                json_data = self.sub.json
-                json_data["time"] = granted_time
                 measurement = MeasurementArray(**self.sub.json)
                 measurement_dict = {key: value for key, value in zip(measurement.ids, measurement.values, strict=False)}
-                measurement_dict["time"] = measurement.time.strftime("%Y-%m-%d %H:%M:%S")
+                # %f keeps microseconds so sub-millisecond EMT timesteps are not truncated.
+                measurement_dict["time"] = (
+                    measurement.time.strftime("%Y-%m-%d %H:%M:%S.%f") if measurement.time is not None else ""
+                )
                 logger.debug(measurement.time)
 
                 if start:
@@ -121,11 +125,12 @@ def run_simulator(broker_config: BrokerConfig):
         name = config["name"]
         feather_path = config["feather_filename"]
         csv_path = config["csv_filename"]
+        time_delta = config.get("time_delta", Recorder.DEFAULT_TIME_DELTA)
 
     with open("input_mapping.json") as f:
         input_mapping = json.load(f)
 
-    sfed = Recorder(name, feather_path, csv_path, input_mapping, broker_config)
+    sfed = Recorder(name, feather_path, csv_path, input_mapping, broker_config, time_delta=time_delta)
     sfed.run()
 
 


### PR DESCRIPTION
## Summary

By default, the recorder does not play nicely with sub-second timestamps, silently dropping that information. This changes that to put the microseconds. A time delta field is also added to support HELICS time deltas of < 0.01 (the current default). This is so EMT simulations can use 0.001 time deltas.

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] New component

## Component Impact

List affected components:

- recorder

## Required Checks

- [X] Linting passes
- [X] Formatting checks pass
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)

## New Component Requirements

Complete this section if this PR adds a new component.

- [ ] Component directory follows existing structure and conventions in `docs/component-structure.md`
- [ ] `component_definition.json` is included and valid
- [ ] `README.md` is included and documents usage
- [ ] `Dockerfile` is included
- [ ] `.gitmodules` is updated for the new component submodule
- [ ] Unit test workflow added: `.github/workflows/unit-test-<component>.yml`
- [ ] Component verification workflow added: `.github/workflows/verify-components-<component>.yml`
- [ ] Dockerfile verification workflow added: `.github/workflows/verify-dockerfiles-<component>.yml`
- [ ] New wiring diagram added to `scenarios/` (for example, `<component>_system.json`)
- [ ] Integration test added and uses the new wiring diagram in `scenarios/`
- [ ] Any required updates to root workflows are included and do not duplicate runs